### PR TITLE
Deprecate TimePeriod's `combine`

### DIFF
--- a/temporals/interfaces/time_period.py
+++ b/temporals/interfaces/time_period.py
@@ -8,5 +8,9 @@ class AbstractTimePeriod(AbstractPeriod):
     """
 
     @abstractmethod
-    def combine(self, other):
+    def to_wallclock(self, other):
+        ...
+
+    @abstractmethod
+    def to_absolute(self, other, timezone):
         ...

--- a/temporals/pydatetime/interface.py
+++ b/temporals/pydatetime/interface.py
@@ -1,4 +1,5 @@
 from typing import Union
+from zoneinfo import ZoneInfo
 from temporals.interfaces import AbstractTimePeriod, AbstractDatePeriod, AbstractDateTimePeriod
 from abc import ABC, abstractmethod
 from datetime import time, date, datetime
@@ -45,9 +46,12 @@ class PyTimePeriod(AbstractTimePeriod, ABC):
         ...
 
     @abstractmethod
-    def combine(self, other: Union['PyDatePeriod', date]) -> 'PyDateTimePeriod':
+    def to_wallclock(self, other: Union['PyDatePeriod', date]) -> 'PyWallClockPeriod':
         ...
 
+    @abstractmethod
+    def to_absolute(self, other: Union['PyDatePeriod', date], timezone: ZoneInfo) -> 'PyAbsolutePeriod':
+        ...
 
 class PyDatePeriod(AbstractDatePeriod, ABC):
 

--- a/temporals/pydatetime/tests/test_timeperiod.py
+++ b/temporals/pydatetime/tests/test_timeperiod.py
@@ -1,5 +1,9 @@
+from zoneinfo import ZoneInfo
+
 import pytest
 from datetime import time, date, datetime
+
+from temporals.pydatetime import WallClockPeriod, AbsolutePeriod
 from temporals.pydatetime.periods import TimePeriod, DatetimePeriod, DatePeriod
 
 
@@ -113,19 +117,28 @@ class TestTimePeriod:
         self.other_period = TimePeriod(start=self.other_start, end=self.other_end)
         assert self.period.is_after(self.other_period) is True
 
-    def test_combine(self):
+    def test_to_wallclock_date(self):
         self.start = time(8, 0)
         self.end = time(12, 0)
         self.period = TimePeriod(start=self.start, end=self.end)
-        assert self.period.combine(date(2024, 1, 1)) == DatetimePeriod(
+
+        wc_period = self.period.to_wallclock(specific_date=date(2024, 1, 1))
+        assert wc_period == WallClockPeriod(
             start=datetime(2024, 1, 1, 8, 0),
             end=datetime(2024, 1, 1, 12, 0)
         )
 
+    def test_to_wallclock_period(self):
+        self.start = time(8, 0)
+        self.end = time(12, 0)
+        self.period = TimePeriod(start=self.start, end=self.end)
+
         self.other_start = date(2024, 1, 10)
         self.other_end = date(2024, 1, 20)
         self.other_period = DatePeriod(start=self.other_start, end=self.other_end)
-        assert self.period.combine(self.other_period) == DatetimePeriod(
+
+        wc_period = self.period.to_wallclock(specific_date=self.other_period)
+        assert wc_period == WallClockPeriod(
             start=datetime(2024, 1, 10, 8, 0),
             end=datetime(2024, 1, 20, 12, 0)
         )

--- a/temporals/pydatetime/tests/test_timeperiod.py
+++ b/temporals/pydatetime/tests/test_timeperiod.py
@@ -1,8 +1,6 @@
 from zoneinfo import ZoneInfo
-
 import pytest
 from datetime import time, date, datetime
-
 from temporals.pydatetime import WallClockPeriod, AbsolutePeriod
 from temporals.pydatetime.periods import TimePeriod, DatetimePeriod, DatePeriod
 
@@ -141,6 +139,34 @@ class TestTimePeriod:
         assert wc_period == WallClockPeriod(
             start=datetime(2024, 1, 10, 8, 0),
             end=datetime(2024, 1, 20, 12, 0)
+        )
+
+    def test_to_absolute_date(self):
+        self.start = time(8, 0)
+        self.end = time(12, 0)
+        self.period = TimePeriod(start=self.start, end=self.end)
+
+        abs_period = self.period.to_absolute(specific_date=date(2024, 1, 1),
+                                             timezone=ZoneInfo("Europe/Paris"))
+        assert abs_period == AbsolutePeriod(
+            start=datetime(2024, 1, 1, 8, 0, tzinfo=ZoneInfo("Europe/Paris")),
+            end=datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Europe/Paris"))
+        )
+
+    def test_to_absolute_period(self):
+        self.start = time(8, 0)
+        self.end = time(12, 0)
+        self.period = TimePeriod(start=self.start, end=self.end)
+
+        self.other_start = date(2024, 1, 10)
+        self.other_end = date(2024, 1, 20)
+        self.other_period = DatePeriod(start=self.other_start, end=self.other_end)
+
+        abs_period = self.period.to_absolute(specific_date=self.other_period,
+                                             timezone=ZoneInfo("Europe/Paris"))
+        assert abs_period == AbsolutePeriod(
+            start=datetime(2024, 1, 10, 8, 0, tzinfo=ZoneInfo("Europe/Paris")),
+            end=datetime(2024, 1, 20, 12, 0, tzinfo=ZoneInfo("Europe/Paris"))
         )
 
     def test_get_interim(self):


### PR DESCRIPTION
`combine` did not reflect the recently introduced distinction between wall clock and absolute periods; 2 new methods have been introduced - `to_wallclock` and `to_absolute` which take the place of `combine`